### PR TITLE
Fix: Prevent implicit float-to-int conversion in PHP 8.1 when indexin…

### DIFF
--- a/qrcode/qrencode.php
+++ b/qrcode/qrencode.php
@@ -127,26 +127,25 @@
         }
         
         //----------------------------------------------------------------------
-        public function getCode()
+         public function getCode()
         {
-            $ret;
-
+            $ret = NULL;
             if($this->count < $this->dataLength) {
-                $row = $this->count % $this->blocks;
-                $col = $this->count / $this->blocks;
+                $row = (int)  $this->count % $this->blocks;
+                $col = intdiv($this->count, $this->blocks);
                 if($col >= $this->rsblocks[0]->dataLength) {
                     $row += $this->b1;
                 }
                 $ret = $this->rsblocks[$row]->data[$col];
             } else if($this->count < $this->dataLength + $this->eccLength) {
-                $row = ($this->count - $this->dataLength) % $this->blocks;
-                $col = ($this->count - $this->dataLength) / $this->blocks;
+                $row = (int) (($this->count - $this->dataLength) % $this->blocks);
+                $col = (int) (($this->count - $this->dataLength) / $this->blocks);
                 $ret = $this->rsblocks[$row]->ecc[$col];
             } else {
                 return 0;
             }
             $this->count++;
-            
+
             return $ret;
         }
     }


### PR DESCRIPTION
This pull request resolves a compatibility issue with PHP 8.1 in the file. Specifically, it prevents implicit float-to-int conversions when indexing arrays, which previously triggered hundreds of warnings during QR code generation.
The fix ensures that all array indices are explicitly cast or calculated as integers using  or rounding, preserving the integrity of the QR code output.
The solution has been validated by:
• 	Running the code in a PHP 8.1 environment with no warnings or notices.
• 	Confirming that the generated QR codes are valid and scannable using standard QR readers.
Backward compatibility with earlier PHP versions is maintained, as the changes rely only on standard integer operations and do not introduce any breaking syntax or dependencies.
